### PR TITLE
Organize YAMLs by dashobard-row-panel in describe/save dashboard cmd

### DIFF
--- a/command/describe.go
+++ b/command/describe.go
@@ -17,6 +17,7 @@ func (d *Describe) Commands() []cli.Command {
 		{
 			Name:   "dashboard",
 			Usage:  "get dashboard in yaml format",
+			Flags:  dashboard.Flags(),
 			Action: dashboard.Execute,
 		},
 		{

--- a/command/describe/dashboard.go
+++ b/command/describe/dashboard.go
@@ -1,16 +1,20 @@
 package describe
 
 import (
-	"errors"
+	"encoding/json"
 	"fmt"
+	"path/filepath"
 
-	"github.com/ghodss/yaml"
 	"github.com/hajarbleh/grafcli/client"
 	"github.com/hajarbleh/grafcli/config"
+	"github.com/hajarbleh/grafcli/utility"
+	"github.com/pkg/errors"
 	"github.com/urfave/cli"
+	"gopkg.in/yaml.v2"
 )
 
 type Dashboard struct {
+	OutputDir string
 }
 
 func (d *Dashboard) Execute(ctx *cli.Context) error {
@@ -27,17 +31,83 @@ func (d *Dashboard) Execute(ctx *cli.Context) error {
 		return err
 	}
 
-	y, err := yaml.JSONToYAML([]byte(body))
-	if err != nil {
-		fmt.Println(err.Error())
+	data := map[string]interface{}{}
+	if err := json.Unmarshal(body, &data); err != nil {
+		fmt.Println(err)
 		return err
 	}
 
-	fmt.Println(string([]byte(y)))
-
+	dashboard := data["dashboard"].(map[string]interface{})
+	name := utility.SanitizeFilename(dashboard["title"].(string))
+	if err := d.writeDashboard(dashboard, filepath.Join(d.OutputDir, name)); err != nil {
+		fmt.Println(err)
+		return err
+	}
 	return nil
 }
 
+func (d *Dashboard) writeDashboard(data map[string]interface{}, outPth string) error {
+	rows := data["rows"].([]interface{})
+	delete(data, "rows") // exclude row data from dashboard YAML.
+	if err := d.writeMapToYAML(data, outPth+".yml"); err != nil {
+		return errors.Wrap(err, "error saving dashboard data")
+	}
+
+	for i, rowi := range rows {
+		row := rowi.(map[string]interface{})
+		name := d.outputFilename(row["title"].(string), i, len(rows))
+		if err := d.writeRow(row, filepath.Join(outPth, name)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *Dashboard) writeRow(data map[string]interface{}, outPth string) error {
+	panels := data["panels"].([]interface{})
+	delete(data, "panels") // exclude panel data from row YAML.
+	if err := d.writeMapToYAML(data, outPth+".yml"); err != nil {
+		return errors.Wrap(err, "error saving row data")
+	}
+
+	for i, paneli := range panels {
+		panel := paneli.(map[string]interface{})
+		name := d.outputFilename(panel["title"].(string), i, len(panels))
+		if err := d.writePanel(panel, filepath.Join(outPth, name)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *Dashboard) writePanel(data map[string]interface{}, outPth string) error {
+	return d.writeMapToYAML(data, outPth+".yml")
+}
+
+func (d *Dashboard) writeMapToYAML(data map[string]interface{}, outPth string) error {
+	yml, err := yaml.Marshal(data)
+	if err != nil {
+		return err
+	}
+	return utility.WriteFile(yml, outPth)
+}
+
+// outputFilename generates proper filename for output YAMLs.
+func (d *Dashboard) outputFilename(title string, order, totalItem int) string {
+	title = utility.SanitizeFilename(title)
+
+	// add number prefix to retain actual ordering in Grafana.
+	pad := fmt.Sprintf("%v", len(fmt.Sprintf("%v", totalItem)))
+	return fmt.Sprintf("%0"+pad+".f_%s", float64(order), title)
+}
+
 func (d *Dashboard) Flags() []cli.Flag {
-	return []cli.Flag{}
+	return []cli.Flag{
+		cli.StringFlag{
+			Name:        "o",
+			Usage:       "Output directory",
+			Value:       ".",
+			Destination: &d.OutputDir,
+		},
+	}
 }

--- a/command/save/dashboard.go
+++ b/command/save/dashboard.go
@@ -7,12 +7,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/hajarbleh/grafcli/client"
 	"github.com/hajarbleh/grafcli/config"
 	"github.com/hajarbleh/grafcli/utility"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
+	"gopkg.in/yaml.v2"
 )
 
 type Dashboard struct {

--- a/command/save/panel.go
+++ b/command/save/panel.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/ghodss/yaml"
 	"github.com/hajarbleh/grafcli/client"
 	"github.com/hajarbleh/grafcli/config"
 	"github.com/hajarbleh/grafcli/template"
 	"github.com/urfave/cli"
+	"gopkg.in/yaml.v2"
 )
 
 type Panel struct {

--- a/command/save/row.go
+++ b/command/save/row.go
@@ -7,11 +7,11 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/hajarbleh/grafcli/client"
 	"github.com/hajarbleh/grafcli/config"
 	"github.com/hajarbleh/grafcli/template"
 	"github.com/urfave/cli"
+	"gopkg.in/yaml.v2"
 )
 
 type Row struct {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/hajarbleh/grafcli
 go 1.12
 
 require (
-	github.com/ghodss/yaml v1.0.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.8.1
 	github.com/urfave/cli v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
-github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=

--- a/utility/fs.go
+++ b/utility/fs.go
@@ -1,0 +1,42 @@
+package utility
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// ListFiles lists all files (excluding directories) in given dirPth. Returns the
+// path of the files.
+func ListFiles(dirPth string) ([]string, error) {
+	infos, err := ioutil.ReadDir(dirPth)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := []string{}
+	for _, info := range infos {
+		if !info.IsDir() {
+			ret = append(ret, filepath.Join(dirPth, info.Name()))
+		}
+	}
+	return ret, nil
+}
+
+// SanitizeFilename lower case & replace non-alphanumeric characters with
+// underscores from given string.
+func SanitizeFilename(name string) string {
+	name = regexp.MustCompile(`\W+`).ReplaceAllString(name, "_")
+	return strings.ToLower(name)
+}
+
+// WriteFile writes data into filePth. Will also create the directories first if
+// required.
+func WriteFile(data []byte, filePth string) error {
+	if err := os.MkdirAll(filepath.Dir(filePth), 0755); err != nil {
+		return err
+	}
+	return ioutil.WriteFile(filePth, data, 0644)
+}


### PR DESCRIPTION
- `describe dashboard dashboard_title` now outputs directly to files with this structure:

      dashboard_title.yml
      dashboard_title
        ├ 0_row_one.yml
        ├ 0_row_one
        │   ├ 0_panel_one.yml
        │   └ 1_panel_two.yml
        ├ 1_row_two.yml
        └ 1_row_two
            ├ 0_panel_three.yml
            └ 1_panel_four.yml

  note: the numbering prefix for rows and panels is necessary to keep their order from Grafana.
- added `-o` flag to `describe dashboard` to determine output directory.
- changed flag `-f` in `save dashboard`, it should now be given the path to dashboard's YAML file (`dashboard_title.yml` in above example).

also removed dependency to `github.com/ghodss/yaml` as it shouldn't be needed anymore.