### PR TITLE
use ghodss/yaml for better compatibility w/ json pkg

### DIFF
--- a/command/describe/dashboard.go
+++ b/command/describe/dashboard.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hajarbleh/grafcli/utility"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
-	"gopkg.in/yaml.v2"
+	"github.com/ghodss/yaml"
 )
 
 type Dashboard struct {

--- a/command/describe/panel.go
+++ b/command/describe/panel.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hajarbleh/grafcli/config"
 	"github.com/hajarbleh/grafcli/template"
 	"github.com/urfave/cli"
-	"gopkg.in/yaml.v2"
+	"github.com/ghodss/yaml"
 )
 
 type Panel struct {

--- a/command/describe/row.go
+++ b/command/describe/row.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hajarbleh/grafcli/config"
 	"github.com/hajarbleh/grafcli/template"
 	"github.com/urfave/cli"
-	"gopkg.in/yaml.v2"
+	"github.com/ghodss/yaml"
 )
 
 type Row struct {

--- a/command/save/dashboard.go
+++ b/command/save/dashboard.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hajarbleh/grafcli/utility"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
-	"gopkg.in/yaml.v2"
+	"github.com/ghodss/yaml"
 )
 
 type Dashboard struct {

--- a/command/save/panel.go
+++ b/command/save/panel.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hajarbleh/grafcli/config"
 	"github.com/hajarbleh/grafcli/template"
 	"github.com/urfave/cli"
-	"gopkg.in/yaml.v2"
+	"github.com/ghodss/yaml"
 )
 
 type Panel struct {

--- a/command/save/row.go
+++ b/command/save/row.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hajarbleh/grafcli/config"
 	"github.com/hajarbleh/grafcli/template"
 	"github.com/urfave/cli"
-	"gopkg.in/yaml.v2"
+	"github.com/ghodss/yaml"
 )
 
 type Row struct {

--- a/config/config.go
+++ b/config/config.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
+	"github.com/ghodss/yaml"
 
 	homedir "github.com/mitchellh/go-homedir"
 )

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,9 @@ module github.com/hajarbleh/grafcli
 go 1.12
 
 require (
+	github.com/ghodss/yaml v1.0.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.8.1
 	github.com/urfave/cli v1.20.0
-	gopkg.in/yaml.v2 v2.2.2
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
+github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=


### PR DESCRIPTION
```go
import (
	"encoding/json"
	"fmt"

	gyaml "github.com/ghodss/yaml"
	"gopkg.in/yaml.v2"
)

func main() {
	str := "foo:\n  bar: baz"
	m := map[string]interface{}{}

	yaml.Unmarshal([]byte(str), &m)
	fmt.Printf("%T\n", m["foo"]) // map[interface {}]interface {}
	_, err := json.Marshal(m)
	fmt.Println(err)             // json: unsupported type: map[interface {}]interface {}

	gyaml.Unmarshal([]byte(str), &m)
	fmt.Printf("%T\n", m["foo"]) // map[string]interface {}
	_, err = json.Marshal(m)
	fmt.Println(err)             // <nil>
}
```

`save dashboard` command is currently broken, this PR should fix it.